### PR TITLE
Remove remaining references to url

### DIFF
--- a/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_classification_evidence-accumulation_bsshslm_2020.py
@@ -113,8 +113,8 @@ np.random.seed(rng_seed)  # fix numpy random seed
 # classification error is tested in regular intervals and the training stopped as soon as the error selected as
 # stop criterion is reached. After training, the performance can be tested over a number of test iterations.
 
-batch_size = 32  # batch size, 64 in reference [2], 32 in the README to reference [2]
-n_iter_train = 50  # number of training iterations, 2000 in reference [2]
+batch_size = 32  # batch size, 64 in the original TensorFlow code and 32 in its README
+n_iter_train = 50  # number of training iterations, 2000 in the original TensorFlow code
 n_iter_test = 4  # number of iterations for final test
 do_early_stopping = True  # if True, stop training as soon as stop criterion fulfilled
 n_iter_validate_every = 10  # number of training iterations before validation

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves.py
@@ -109,7 +109,7 @@ np.random.seed(rng_seed)  # fix numpy random seed
 # learning performance.
 
 group_size = 1  # number of instances over which to evaluate the learning performance
-n_iter = 200  # number of iterations, 2000 in reference [2]
+n_iter = 200  # number of iterations, 2000 in the original TensorFlow code
 
 steps = {
     "sequence": 1000,  # time steps of one full sequence

--- a/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
+++ b/pynest/examples/eprop_plasticity/eprop_supervised_regression_sine-waves_bsshslm_2020.py
@@ -103,8 +103,8 @@ np.random.seed(rng_seed)  # fix numpy random seed
 # The task's temporal structure is then defined, once as time steps and once as durations in milliseconds.
 # Increasing the number of iterations enhances learning performance.
 
-batch_size = 1  # batch size, 1 in reference [2]
-n_iter = 200  # number of iterations, 2000 in reference [2]
+batch_size = 1  # batch size, 1 in the original TensorFlow code
+n_iter = 200  # number of iterations, 2000 in the original TensorFlow code
 
 steps = {
     "sequence": 1000,  # time steps of one full sequence


### PR DESCRIPTION
This PR removes the remaining references to the URL in the eprop plasticity examples.